### PR TITLE
feat: add tmoments benchmark

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 VelocityDistributionFunctions = "63a0b508-f74a-48f7-b6e7-0e65849b0078"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,3 +17,17 @@ for (name, d) in [
     g["rand"]     = @benchmarkable rand($d)
     g["rand_1k"]  = @benchmarkable rand($d, 1000)
 end
+
+# tmoments benchmark with synthetic MMS-like data
+let nt = 100, nphi = 32, ntheta = 16, nenergy = 32
+    data = rand(Float32, nt, nphi, ntheta, nenergy)
+    theta = collect(range(-90.0, 90.0, length = ntheta))
+    phi = collect(range(0.0, 360.0, length = nphi + 1)[1:nphi])
+    energy = 10 .^ collect(range(log10(10.0), log10(30000.0), length = nenergy))
+    scpot = zeros(nt)
+    magf = randn(nt, 3)
+
+    g = SUITE["tmoments"] = BenchmarkGroup()
+    g["no_magf"]   = @benchmarkable tmoments($data, $theta, $phi, $energy, $scpot; edim = 4, tdim = 1, units = :df_cm)
+    g["with_magf"] = @benchmarkable tmoments($data, $theta, $phi, $energy, $scpot, $magf; edim = 4, tdim = 1, units = :df_cm)
+end


### PR DESCRIPTION
## Summary

- Add `tmoments` benchmark group to `benchmark/benchmarks.jl`
- Uses synthetic MMS-like data: `(100, 32, 16, 32)` array with `edim=4, tdim=1`
- Two variants: without magnetic field (`no_magf`) and with magnetic field (`with_magf`)