### PR TITLE
refactor: move Unitful into package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,12 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
+
+[weakdeps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[extensions]
+VDFsUnitfulExt = "Unitful"
 
 [compat]
 BaseType = "0.2.0"

--- a/ext/VDFsUnitfulExt.jl
+++ b/ext/VDFsUnitfulExt.jl
@@ -2,8 +2,10 @@ module VDFsUnitfulExt
 
 using VelocityDistributionFunctions
 using VelocityDistributionFunctions: AbstractVelocityPDF, VelocityDistribution
-using VelocityDistributionFunctions: MaxwellianPDF, BiMaxwellianPDF, KappaPDF, BiKappaPDF
-using VelocityDistributionFunctions: kappa_thermal_speed, _pdf
+using VelocityDistributionFunctions: _pdf
+import VelocityDistributionFunctions: MaxwellianPDF, BiMaxwellianPDF, KappaPDF, BiKappaPDF
+import VelocityDistributionFunctions: Maxwellian, BiMaxwellian, Kappa, BiKappa
+import VelocityDistributionFunctions: kappa_thermal_speed
 import Distributions
 using Unitful: upreferred, @derived_dimension
 using Unitful: Quantity, Temperature, Velocity, Pressure
@@ -17,7 +19,7 @@ const NType = Union{NumberDensity, Real}
 
 v_th(T, m) = upreferred(sqrt(2 * k * T / m))
 
-const vth_kappa_ = kappa_thermal_speed
+kappa_thermal_speed(T::Temperature, κ, m) = kappa_thermal_speed(v_th(T, m), κ)
 
 """
     ustrip(d::VelocityDistribution)
@@ -37,10 +39,10 @@ BiMaxwellianPDF(T_perp::Temperature, T_para::Temperature, args...; mass = me, kw
     BiMaxwellianPDF(v_th(T_perp, mass), v_th(T_para, mass), args...; kw...)
 
 KappaPDF(T_perp::Temperature, κ; mass = me, kw...) =
-    KappaPDF(vth_kappa_(T_perp, κ, mass), κ; kw...)
+    KappaPDF(kappa_thermal_speed(T_perp, κ, mass), κ; kw...)
 
 BiKappaPDF(T_perp::Temperature, T_para::Temperature, κ, args...; mass = me, kw...) =
-    BiKappaPDF(vth_kappa_(T_perp, κ, mass), vth_kappa_(T_para, κ, mass), κ, args...; kw...)
+    BiKappaPDF(kappa_thermal_speed(T_perp, κ, mass), kappa_thermal_speed(T_para, κ, mass), κ, args...; kw...)
 
 Distributions.pdf(d::AbstractVelocityPDF, v::AbstractVector{<:Velocity}) = _pdf(d, v)
 

--- a/ext/VDFsUnitfulExt.jl
+++ b/ext/VDFsUnitfulExt.jl
@@ -1,11 +1,20 @@
+module VDFsUnitfulExt
+
+using VelocityDistributionFunctions
+using VelocityDistributionFunctions: AbstractVelocityPDF, VelocityDistribution
+using VelocityDistributionFunctions: MaxwellianPDF, BiMaxwellianPDF, KappaPDF, BiKappaPDF
+using VelocityDistributionFunctions: kappa_thermal_speed, _pdf
+import Distributions
 using Unitful: upreferred, @derived_dimension
 using Unitful: Quantity, Temperature, Velocity, Pressure
 using Unitful: me, k
 import Unitful: ustrip
 using ConstructionBase: constructorof, getfields
 using Unitful: 𝐋
+
 @derived_dimension NumberDensity 𝐋^-3
 const NType = Union{NumberDensity, Real}
+
 v_th(T, m) = upreferred(sqrt(2 * k * T / m))
 
 const vth_kappa_ = kappa_thermal_speed
@@ -46,4 +55,6 @@ end
 for f in (:BiMaxwellian, :BiKappa)
     @eval $f(n::NumberDensity, p_perp::Pressure, p_para::Pressure, args...; kw...) =
         VelocityDistribution(n, $f(p_perp / (n * k), p_para / (n * k), args...; kw...))
+end
+
 end

--- a/src/distributions/Distributions.jl
+++ b/src/distributions/Distributions.jl
@@ -48,8 +48,6 @@ for (f, g) in [(:Maxwellian, :MaxwellianPDF), (:BiMaxwellian, :BiMaxwellianPDF),
     end
 end
 
-include("VDFsUnitfulExt.jl")
-
 function Distributions.pdf(vdf::Union{MaxwellianPDF, KappaPDF}, v::V)
     v² = v.val^2
     return 4π * v² * _pdf_v²(vdf, v²)

--- a/src/distributions/Kappa.jl
+++ b/src/distributions/Kappa.jl
@@ -33,17 +33,18 @@ struct KappaPDF{T, K <: Real} <: KappaDistribution{T, K}
 end
 
 """
-    kappa_thermal_speed(T, κ, m)
+    kappa_thermal_speed(vth, κ)
+    kappa_thermal_speed(T::Temperature, κ, m)  # requires Unitful
 
-Return the most probable speed of a (modified) kappa distribution with κ-Independent temperature `T`.
+Return the most probable speed of a (modified) kappa distribution.
+
+The second form (accepting `Temperature`) is available when `Unitful` is loaded.
 
 ```math
-V_{th} = \\sqrt{\\frac{κ - 3/2}{κ} \\frac{2 k_B T}{m}}
+V_{th,κ} = v_{th} \\sqrt{\\frac{κ - 3/2}{κ}}
 ```
 """
-function kappa_thermal_speed(T, κ, m)
-    return upreferred(sqrt(2 * k * T / m)) * sqrt((κ - 3 / 2) / κ)
-end
+kappa_thermal_speed(vth, κ) = vth * sqrt((κ - 3/2) / κ)
 
 
 _Aκ(κ, vth) = gamma(κ + 1) / gamma(κ - 1 / 2) / √((π * κ)^3) / vth^3


### PR DESCRIPTION
## Summary

- Move `src/distributions/VDFsUnitfulExt.jl` → `ext/VDFsUnitfulExt.jl` as a proper Julia package extension
- `Unitful` becomes a weak dependency — only loaded when the user loads `Unitful` themselves
- Remove `include("VDFsUnitfulExt.jl")` from `src/distributions/Distributions.jl`
- `ConstructionBase` stays in `[deps]` since it's always needed by the extension

All Unitful-dependent functionality (constructors accepting `Temperature`, `ustrip`, etc.) remains available — the extension is automatically triggered when `using Unitful` is called.